### PR TITLE
Prevent users from creating multiple accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# v2.9.0 (2026-03-02)
+
+### Changed
+
+- First ESPCI SSO authentication no longer creates a new account when it detects a preexisting one.
+- Rezident account creation now grants the Rezident role to accounts that already exist instead of creating a new one. 
+
 # v2.8.2 (2025-04-04)
 
 ### Fixed

--- a/Merge_account_template.sql
+++ b/Merge_account_template.sql
@@ -1,0 +1,73 @@
+-- Script générique pour migrer toutes les informations d'un compte PEM vers un autre compte. Il transfère toutes les informations, l'historique des transactions, balance bar...
+DO $$
+DECLARE
+    old_id_here INT := 1874;     -- ID du compte à supprimer
+    target_id_here INT := 1781;  -- ID du compte vers lequel migrer les données
+BEGIN
+
+-- Suppression des rôles en doublon
+DELETE FROM _pceen_role_at old_role
+USING _pceen_role_at target_role
+WHERE old_role._pceen_id = old_id_here
+  AND target_role._pceen_id = target_id_here
+  AND old_role._role_id = target_role._role_id;
+
+-- Ajout des rôles restants
+UPDATE _pceen_role_at
+SET _pceen_id = target_id_here
+WHERE _pceen_id = old_id_here;
+
+-- Gestion spéciale du bar_daily_data (au cas où les deux comptes ont une activité sur le même jour)
+UPDATE bar_daily_data target_data
+SET 
+    balance_change = target_data.balance_change + old_data.balance_change,
+    items_bought_count = target_data.items_bought_count + old_data.items_bought_count,
+    alcohol_bought_count = target_data.alcohol_bought_count + old_data.alcohol_bought_count,
+    total_spent = target_data.total_spent + old_data.total_spent
+FROM bar_daily_data old_data
+WHERE target_data._pceen_id = target_id_here
+  AND old_data._pceen_id = old_id_here
+  AND target_data.date = old_data.date;
+
+-- Nettoyage
+DELETE FROM bar_daily_data old_data
+USING bar_daily_data target_data
+WHERE old_data._pceen_id = old_id_here
+  AND target_data._pceen_id = target_id_here
+  AND target_data.date = old_data.date;
+
+
+UPDATE bar_daily_data
+SET _pceen_id = target_id_here
+WHERE _pceen_id = old_id_here;
+
+-- Migration de la balance
+UPDATE pceen AS target
+SET bar_balance = COALESCE(target.bar_balance, 0) + COALESCE(old.bar_balance, 0)
+FROM pceen AS old
+WHERE target.id = target_id_here 
+  AND old.id = old_id_here;
+
+UPDATE pceen
+SET bar_balance = 0
+WHERE id = old_id_here;
+
+
+-- Tout le reste
+UPDATE bar_transaction SET _client_id = target_id_here WHERE _client_id = old_id_here;
+UPDATE bar_transaction SET _barman_id = target_id_here WHERE _barman_id = old_id_here;
+UPDATE bar_transaction SET _reverter_id = target_id_here WHERE _reverter_id = old_id_here;
+
+UPDATE subscription SET _pceen_id = target_id_here WHERE _pceen_id = old_id_here;
+UPDATE payment SET _pceen_id = target_id_here WHERE _pceen_id = old_id_here;
+UPDATE ban SET _pceen_id = target_id_here WHERE _pceen_id = old_id_here;
+UPDATE device SET _pceen_id = target_id_here WHERE _pceen_id = old_id_here;
+UPDATE club_q_voeu SET _pceen_id = target_id_here WHERE _pceen_id = old_id_here;
+UPDATE order_panier_bio SET _pceen_id = target_id_here WHERE _pceen_id = old_id_here;
+UPDATE rental SET _pceen_id = target_id_here WHERE _pceen_id = old_id_here;
+UPDATE photo SET _author_id = target_id_here WHERE _author_id = old_id_here;
+
+-- Suppression de l'ancien compte
+DELETE FROM pceen WHERE id = old_id_here;
+
+END $$;

--- a/Migration_example.sql
+++ b/Migration_example.sql
@@ -1,0 +1,272 @@
+-- Ce script est une requête SQL pour migrer chaque compte @espci.psl.eu vers son compte PEM "classique" correspondant. 
+
+alter table pceen add espci_email VARCHAR(255) ;
+
+-- Copie de l'email pcéen sur le compte principal
+UPDATE pceen AS p1
+SET espci_email = p2.email
+FROM pceen AS p2
+WHERE p1.nom = p2.nom 
+  AND p1.prenom = p2.prenom 
+  AND p1.promo = p2.promo
+  AND p1.email NOT LIKE '%@espci.psl.eu' 
+  AND p2.email LIKE '%@espci.psl.eu';
+
+
+SELECT 
+    p1.nom, 
+    p1.prenom, 
+    p1.promo, 
+    p1.email AS personal_email, 
+    p2.email AS new_espci_email
+FROM pceen p1
+JOIN pceen p2 
+    ON p1.nom = p2.nom 
+    AND p1.prenom = p2.prenom 
+    AND p1.promo = p2.promo
+WHERE p1.email NOT LIKE '%@espci.psl.eu' 
+  AND p2.email LIKE '%@espci.psl.eu';
+
+-- Migration du solde du bar (bar_balance)
+-- 1. Ajout du solde de l'ancien compte au compte principal
+UPDATE pceen AS p_prim
+SET bar_balance = COALESCE(p_prim.bar_balance, 0) + COALESCE(p_dup.bar_balance, 0)
+FROM pceen AS p_dup
+WHERE p_prim.nom = p_dup.nom 
+  AND p_prim.prenom = p_dup.prenom 
+  AND p_prim.promo = p_dup.promo
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+-- 2. Mise à zéro du solde de l'ancien compte
+UPDATE pceen AS p_dup
+SET bar_balance = 0
+FROM pceen AS p_prim
+WHERE p_dup.nom = p_prim.nom 
+  AND p_dup.prenom = p_prim.prenom 
+  AND p_dup.promo = p_prim.promo
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+-- =======================================================
+
+
+-- Migration des données supplémentaires
+
+-- Migration du bar (transactions)
+UPDATE bar_transaction AS bt
+SET _client_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE bt._client_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+  UPDATE subscription AS s
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE s._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+UPDATE payment AS p
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE p._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+-- Cas pour gérer les doublons
+DELETE FROM _pceen_role_at AS pra_dup
+USING pceen AS p_dup, 
+      pceen AS p_prim, 
+      _pceen_role_at AS pra_prim
+WHERE pra_dup._pceen_id = p_dup.id
+  AND p_dup.nom = p_prim.nom 
+  AND p_dup.prenom = p_prim.prenom 
+  AND p_dup.promo = p_prim.promo
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu'
+  -- Supprimer seulement si le rôle est en doublon
+  AND pra_prim._pceen_id = p_prim.id
+  AND pra_dup._role_id = pra_prim._role_id;
+
+  UPDATE _pceen_role_at AS pra
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE pra._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+ UPDATE ban AS b
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE b._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+-- Update du bar daily
+
+UPDATE bar_daily_data AS bdd_prim
+SET 
+    balance_change = bdd_prim.balance_change + bdd_dup.balance_change,
+    items_bought_count = bdd_prim.items_bought_count + bdd_dup.items_bought_count,
+    alcohol_bought_count = bdd_prim.alcohol_bought_count + bdd_dup.alcohol_bought_count,
+    total_spent = bdd_prim.total_spent + bdd_dup.total_spent
+FROM bar_daily_data AS bdd_dup
+JOIN pceen AS p_dup ON bdd_dup._pceen_id = p_dup.id
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE bdd_prim._pceen_id = p_prim.id
+  AND bdd_prim.date = bdd_dup.date -- Gestion spéciale pour les cas où les 2 comptes ont une activité au bar ce jour-ci
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+
+DELETE FROM bar_daily_data AS bdd_dup
+USING pceen AS p_dup,
+      pceen AS p_prim,
+      bar_daily_data AS bdd_prim
+WHERE bdd_dup._pceen_id = p_dup.id
+  AND p_dup.nom = p_prim.nom 
+  AND p_dup.prenom = p_prim.prenom 
+  AND p_dup.promo = p_prim.promo
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu'
+  AND bdd_prim._pceen_id = p_prim.id
+  AND bdd_prim.date = bdd_dup.date;
+
+
+UPDATE bar_daily_data AS bdd
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE bdd._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+-- Update des devices
+
+
+UPDATE device AS d
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE d._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+
+  UPDATE club_q_voeu AS cqv
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE cqv._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+
+ UPDATE order_panier_bio AS opb
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE opb._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+
+ UPDATE rental AS r
+SET _pceen_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE r._pceen_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+ UPDATE photo AS ph
+SET _author_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE ph._author_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+  UPDATE bar_transaction AS bt
+SET _barman_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE bt._barman_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+
+  UPDATE bar_transaction AS bt
+SET _reverter_id = p_prim.id
+FROM pceen AS p_dup
+JOIN pceen AS p_prim ON p_dup.nom = p_prim.nom 
+                    AND p_dup.prenom = p_prim.prenom 
+                    AND p_dup.promo = p_prim.promo
+WHERE bt._reverter_id = p_dup.id
+  AND p_dup.email LIKE '%@espci.psl.eu'
+  AND p_dup.espci_email IS NULL
+  AND p_prim.email NOT LIKE '%@espci.psl.eu';
+
+-- Déletion finale !!!
+
+DELETE FROM pceen p_dup
+WHERE email LIKE '%@espci.psl.eu'
+  AND espci_email IS NULL
+  AND EXISTS (
+      SELECT 1 
+      FROM pceen p_prim 
+      WHERE p_prim.nom = p_dup.nom 
+        AND p_prim.prenom = p_dup.prenom 
+        AND p_prim.promo = p_dup.promo 
+        AND p_prim.email NOT LIKE '%@espci.psl.eu'
+  );
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Application Flask tournant sur https://pc-est-magique.fr.
 Seules les fonctionnalités majeures sont listées ici ; voir
 [`CHANGELOG.md`](CHANGELOG.md) pour les détails.
 
+### 2.9
+
+- Refonte du système de comptes pour empêcher la création de plus d'un compte par personne. 
+
 ### 2.8
 
 - Ajout du module du Panier Bio sur pc-est-magique : possibilité de commander des panier bios et de suivre son historique. Page d'administration pour le suivi des gérants.

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -12,6 +12,7 @@ from flask_babel import _
 import flask_login
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import hybrid_property
+from unidecode import unidecode
 from sqlalchemy.orm import Query
 from werkzeug import security as wzs
 
@@ -184,6 +185,30 @@ class PCeen(flask_login.UserMixin, Model):
         if not public_role:
             return False
         return cls._has_permission(public_role.permissions, type, scope, elem)
+
+    @classmethod
+    def find_by_fuzzy_name(cls, nom: str, prenom: str, promo: int | None) -> PCeen | None:
+        """Find a PCeen by a fuzzy name (unaccented + lowercased) and promo.
+        
+        Args:
+            nom: The user's last name.
+            prenom: The user's first name.
+            promo: The user's promotion number.
+            
+        Returns:
+            The matching PCeen, if one exists.
+        """
+        if not nom or not prenom or promo is None:
+            return None
+            
+        nom_clean = unidecode(nom.lower())
+        prenom_clean = unidecode(prenom.lower())
+        
+        return cls.query.filter(
+            sa.func.unaccent(sa.func.lower(cls.nom)) == nom_clean,
+            sa.func.unaccent(sa.func.lower(cls.prenom)) == prenom_clean,
+            cls.promo == promo
+        ).first()
 
     @property
     def first_seen(self) -> datetime.datetime:

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -58,6 +58,7 @@ class PCeen(flask_login.UserMixin, Model):
     locale: Column[str | None] = column(sa.String(8), nullable=True)
     is_gri: Column[bool] = column(sa.Boolean(), nullable=False, default=False)
     sub_state: Column[SubState] = column(Enum(SubState), nullable=True)
+    espci_email: Column[str] = column(sa.String(120), unique=True, nullable=True)
 
     # Login info
     activated: Column[bool] = column(sa.Boolean(), nullable=False, default=True)

--- a/app/routes/auth/routes.py
+++ b/app/routes/auth/routes.py
@@ -45,6 +45,7 @@ def register_rezident() -> typing.RouteReturn:
             existing_pceen = PCeen.query.filter_by(nom=nom, prenom=prenom, promo=promo).first()
             if existing_pceen:
                 flask.session["link_rezident_role"] = True
+                helpers.log_action(f"Un utilisateur déjà existant a demandé à devenir Rezident ! ({pceen.full_name} {pceen.promo})")
                 flask.flash(_("Un compte avec ces informations existe déjà. Veuillez vous connecter pour finaliser la création du compte Rezident."), "info")
                 return flask.redirect(flask.url_for("auth.login"))
 

--- a/app/routes/auth/routes.py
+++ b/app/routes/auth/routes.py
@@ -42,10 +42,10 @@ def register_rezident() -> typing.RouteReturn:
         promo = form.promo.data
 
         if nom and prenom and promo is not None:
-            existing_pceen = PCeen.query.filter_by(nom=nom, prenom=prenom, promo=promo).first()
+            existing_pceen = PCeen.find_by_fuzzy_name(nom, prenom, promo)
             if existing_pceen:
                 flask.session["link_rezident_role"] = True
-                helpers.log_action(f"Un utilisateur déjà existant a demandé à devenir Rezident ! ({pceen.full_name} {pceen.promo})")
+                helpers.log_action(f"Un utilisateur déjà existant a demandé à devenir Rezident ! ({existing_pceen.full_name} {existing_pceen.promo})")
                 flask.flash(_("Un compte avec ces informations existe déjà. Veuillez vous connecter pour finaliser la création du compte Rezident."), "info")
                 return flask.redirect(flask.url_for("auth.login"))
 

--- a/app/routes/auth/routes.py
+++ b/app/routes/auth/routes.py
@@ -37,8 +37,11 @@ def register_rezident() -> typing.RouteReturn:
     form = forms.RegistrationForm()
 
     if form.is_submitted():
-        nom = form.nom.data.title() if form.nom.data else ""
-        prenom = form.prenom.data.title() if form.prenom.data else ""
+        if not form.nom.data or not form.prenom.data:
+            raise ValueError(_("Veuillez renseigner votre nom et prénom pour l'inscription."))
+            
+        nom = form.nom.data.title()
+        prenom = form.prenom.data.title()
         promo = form.promo.data
 
         if nom and prenom and promo is not None:

--- a/app/routes/auth/routes.py
+++ b/app/routes/auth/routes.py
@@ -6,7 +6,7 @@ from flask_babel import _
 
 from app import context, db
 from app.routes.auth import bp, forms, email
-from app.models import PCeen
+from app.models import PCeen, Role
 from app.routes.auth.utils import new_username
 from app.utils import helpers, typing
 from app.utils.roles import grant_rezident_role
@@ -35,12 +35,29 @@ def register_rezident() -> typing.RouteReturn:
         return helpers.redirect_to_next()
 
     form = forms.RegistrationForm()
+
+    if form.is_submitted():
+        nom = form.nom.data.title() if form.nom.data else ""
+        prenom = form.prenom.data.title() if form.prenom.data else ""
+        promo = form.promo.data
+
+        if nom and prenom and promo is not None:
+            existing_pceen = PCeen.query.filter_by(nom=nom, prenom=prenom, promo=promo).first()
+            if existing_pceen:
+                flask.session["link_rezident_role"] = True
+                flask.flash(_("Un compte avec ces informations existe déjà. Veuillez vous connecter pour finaliser la création du compte Rezident."), "info")
+                return flask.redirect(flask.url_for("auth.login"))
+
     if form.validate_on_submit():
+        nom = form.nom.data.title()
+        prenom = form.prenom.data.title()
+        promo = form.promo.data
+
         pceen = PCeen(
-            username=new_username(form.prenom.data, form.nom.data),
-            nom=form.nom.data.title(),
-            prenom=form.prenom.data.title(),
-            promo=form.promo.data,
+            username=new_username(prenom, nom),
+            nom=nom,
+            prenom=prenom,
+            promo=promo,
             email=form.email.data,
         )
         pceen.set_password(form.password.data)
@@ -81,7 +98,18 @@ def login() -> typing.RouteReturn:
             if not pceen.activated:
                 pceen.activated = True
                 db.session.commit()
-            flask.flash(_("Connecté !"), "success")
+            
+            if flask.session.pop("link_rezident_role", None):
+                rezident_role = Role.query.filter_by(name="Rezident").one()
+                if rezident_role in pceen.roles:
+                    flask.flash(_("Ce compte possède déjà le rôle Rezident."), "danger")
+                else:
+                    grant_rezident_role(pceen)
+                    db.session.commit()
+                    flask.flash(_("Le rôle Rezident vous a été ajouté."), "success")
+            else:
+                flask.flash(_("Connecté !"), "success")
+                
             return helpers.redirect_to_next()
 
     return flask.render_template("auth/login.html", title=_("Connexion"), form=form)

--- a/app/routes/auth/saml/routes.py
+++ b/app/routes/auth/saml/routes.py
@@ -10,12 +10,14 @@ import saml2.config
 import saml2.entity
 import saml2.metadata
 
+from app import db
 from app.models import PCeen
 from app.routes.auth import email
 from app.routes.auth.saml import bp
 from app.routes.auth.saml.utils import (
     reconciliate_account,
     create_new_account,
+    process_attributes,
     PROMOTIONS_SERVICES,
     SAMLAttributes,
 )
@@ -159,16 +161,36 @@ def acs() -> typing.RouteReturn:
         return helpers.ensure_safe_redirect("auth.auth_needed", next=None)
 
     # Authentication OK, process attributes
+    prenom, nom, extracted_email, promo = process_attributes(attributes)
+    
+    # 1. First Pass: check by exact espci_email
+    pceen_matched = None
     for mail in attributes["mail"]:
-        if pceen := PCeen.query.filter_by(email=mail).first():
-            if not pceen.espci_sso_enabled:
-                reconciliate_account(pceen, attributes)
+        pceen = PCeen.query.filter_by(espci_email=mail).first()
+        if pceen:
+            pceen_matched = pceen
+            break
+            
+    # 2. Second Pass: If not found by espci_email, check by Name + Promo
+    if not pceen_matched and promo is not None:
+        pceen = PCeen.query.filter_by(nom=nom, prenom=prenom, promo=promo).first()
+        if pceen:
+            pceen_matched = pceen
 
-            flask_login.login_user(pceen, remember=False)
-            flask.flash(_("Connecté !"), "success")
-            return helpers.redirect_to_next()
+    if pceen_matched:
+        if not pceen_matched.espci_sso_enabled:
+            reconciliate_account(pceen_matched, attributes)
+        
+        # Ensure we backfill espci_email if it's missing (e.g. for existing accounts matched by name)
+        if not pceen_matched.espci_email:
+             pceen_matched.espci_email = extracted_email
+             db.session.commit()
 
-    # No known address, check if allowed to access
+        flask_login.login_user(pceen_matched, remember=False)
+        flask.flash(_("Connecté !"), "success")
+        return helpers.redirect_to_next()
+
+    # 3. Third Pass: No known address or name, check if allowed to access / create
     if any(service in ACCEPTED_SERVICES for service in attributes["authorizedService"]):
         pceen = create_new_account(attributes)
         email.send_account_registered_email(pceen)

--- a/app/routes/auth/saml/routes.py
+++ b/app/routes/auth/saml/routes.py
@@ -173,7 +173,7 @@ def acs() -> typing.RouteReturn:
             
     # 2. Second Pass: If not found by espci_email, check by Name + Promo
     if not pceen_matched and promo is not None:
-        pceen = PCeen.query.filter_by(nom=nom, prenom=prenom, promo=promo).first()
+        pceen = PCeen.find_by_fuzzy_name(nom, prenom, promo)
         if pceen:
             pceen_matched = pceen
             helpers.log_action(f"SSO ESPCI : Un compte sans SSO lié ({pceen.full_name} {pceen.promo}) a été trouvé et va être lié à l'email {extracted_email}.")

--- a/app/routes/auth/saml/routes.py
+++ b/app/routes/auth/saml/routes.py
@@ -176,6 +176,7 @@ def acs() -> typing.RouteReturn:
         pceen = PCeen.query.filter_by(nom=nom, prenom=prenom, promo=promo).first()
         if pceen:
             pceen_matched = pceen
+            helpers.log_action(f"SSO ESPCI : Un compte sans SSO lié ({pceen.full_name} {pceen.promo}) a été trouvé et va être lié à l'email {extracted_email}.")
 
     if pceen_matched:
         if not pceen_matched.espci_sso_enabled:

--- a/app/routes/auth/saml/utils.py
+++ b/app/routes/auth/saml/utils.py
@@ -61,10 +61,14 @@ def reconciliate_account(pceen: PCeen, attributes: SAMLAttributes) -> None:
         pceen: The PCéen matching the authenticated user.
         attributes: SAML attributes of the authenticated user.
     """
-    prenom, nom, _email, promo = process_attributes(attributes)
+    prenom, nom, email, promo = process_attributes(attributes)
     pceen.prenom = prenom
     pceen.nom = nom
     pceen.promo = promo
+    
+    if not pceen.espci_email:
+        pceen.espci_email = email
+        
     flask.flash(
         _(
             "Compte mis à jour depuis les infos ESPCI (prénom : %(prenom)s, nom : %(nom)s, promotion : %(promo)s)",
@@ -101,6 +105,7 @@ def create_new_account(attributes: SAMLAttributes) -> PCeen:
         prenom=prenom,
         promo=promo,
         email=email,
+        espci_email=email,
         espci_sso_enabled=True,
     )
     if promo:

--- a/app/templates/cards/account.html
+++ b/app/templates/cards/account.html
@@ -33,6 +33,12 @@
     </td>
 </tr>
 <tr>
+    <th scope="row" class="ps-4">{{ _("Email ESPCI") }}</th>
+    <td class="text-break">
+        <a href="mailto:{{ pceen.email }}" class="text-dark">{{ pceen.espci_email }}</a>
+    </td>
+</tr>
+<tr>
     <th scope="row" class="ps-4">{{ _("Rôles") }}</th>
     <td>{{ pceen.roles | join(", ") }}</td>
 </tr>

--- a/app/templates/main/changelog.html
+++ b/app/templates/main/changelog.html
@@ -17,7 +17,7 @@
 </div>
 
 <div class="row mb-2">
-    <h4>v2.9 – {{ moment(datetime.date(2026, 3, 02)).format("L") }}</h4>
+    <h4>v2.9 – {{ moment(datetime.date(2026, 3, 2)).format("L") }}</h4>
     <ul class="ms-5">
         <li>
             {{ _("Refonte du système de comptes pour empêcher la création de plus d'un compte par personne.") }}

--- a/app/templates/main/changelog.html
+++ b/app/templates/main/changelog.html
@@ -17,6 +17,16 @@
 </div>
 
 <div class="row mb-2">
+    <h4>v2.9 – {{ moment(datetime.date(2026, 3, 02)).format("L") }}</h4>
+    <ul class="ms-5">
+        <li>
+            {{ _("Refonte du système de comptes pour empêcher la création de plus d'un compte par personne.") }}
+        </li>
+    </ul>
+</div>
+
+
+<div class="row mb-2">
     <h4>v2.8 – {{ moment(datetime.date(2024, 9, 29)).format("L") }}</h4>
     <ul class="ms-5">
         <li>

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -5701,6 +5701,10 @@ msgstr "Invalid item ID."
 #~ "à un captcha."
 #~ msgstr "Use of contact form from the exterior now needs captcha completation."
 
+#: app/routes/auth/routes.py:41
+msgid "Veuillez renseigner votre nom et prénom pour l'inscription."
+msgstr "Please provide your first and last name to register."
+
 #~ msgid "Ajout du mécanisme de changement de chambre."
 #~ msgstr "Added room change mecanism."
 

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -73,10 +73,22 @@ msgstr "This photo is now the album's thumbnail."
 msgid "Photo définitivement supprimée."
 msgstr "Photo deleted definitively."
 
-#: app/routes/auth/email.py:17 app/routes/auth/routes.py:53
+#: app/routes/auth/email.py:17 app/routes/auth/routes.py:48
+msgid "Un compte avec ces informations existe déjà. Veuillez vous connecter pour finaliser la création du compte Rezident."
+msgstr "Account already exists. Please sign in to finalize the creation of the Rezident account."
+
+#: app/routes/auth/email.py:17 app/routes/auth/routes.py:70
 #: app/routes/auth/saml/routes.py:176
 msgid "Compte créé avec succès !"
 msgstr "Account successfully created!"
+
+#: app/routes/auth/email.py:17 app/routes/auth/routes.py:105
+msgid "Ce compte possède déjà le rôle Rezident."
+msgstr "This accound already has the Rezident role assigned."
+
+#: app/routes/auth/email.py:17 app/routes/auth/routes.py:109
+msgid "Le rôle Rezident vous a été ajouté."
+msgstr "You have been given the Rezident role."
 
 #: app/routes/auth/email.py:38 app/templates/auth/mails/reset_password.html:7
 msgid "Réinitialisation du mot de passe"
@@ -2057,6 +2069,10 @@ msgstr "Observer"
 #: app/templates/bar/user.html:138 app/templates/cards/account.html:30
 msgid "Email"
 msgstr "Mail"
+
+#: app/templates/bar/user.html:138 app/templates/cards/account.html:36
+msgid "Email ESPCI"
+msgstr "ESPCI Mail"
 
 #: app/templates/bar/user.html:147
 msgid "Externe"

--- a/migrations/versions/170f7a7dced9_add_unaccent_extension.py
+++ b/migrations/versions/170f7a7dced9_add_unaccent_extension.py
@@ -18,7 +18,9 @@ depends_on = None
 
 def upgrade():
     op.execute("CREATE EXTENSION IF NOT EXISTS unaccent;")
+    op.add_column("pceen", sa.Column("espci_email", sa.String(length=120), nullable=True))
 
 
 def downgrade():
+    op.drop_column("pceen", "espci_email")
     op.execute("DROP EXTENSION IF EXISTS unaccent;")

--- a/migrations/versions/170f7a7dced9_add_unaccent_extension.py
+++ b/migrations/versions/170f7a7dced9_add_unaccent_extension.py
@@ -1,0 +1,24 @@
+"""Add unaccent extension
+
+Revision ID: 170f7a7dced9
+Revises: fa3a7ab1bc06
+Create Date: 2026-03-02 21:34:48.531423
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '170f7a7dced9'
+down_revision = 'fa3a7ab1bc06'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE EXTENSION IF NOT EXISTS unaccent;")
+
+
+def downgrade():
+    op.execute("DROP EXTENSION IF EXISTS unaccent;")

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pc-est-magique",
-      "version": "2.8.1",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-est-magique",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "PC est magique Flask Web App",
   "main": "n/a",
   "scripts": {


### PR DESCRIPTION
PCéens now have a new espci_email attribute. It is displayed in the profile page.

Rezident authentication now checks for name/surname/promo to avoid creating new accounts needlessly. ESPCI SSO auth does the same.

